### PR TITLE
feat: 결제위젯 추가 및 결제인증 및 승인 API 요청 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wiseshop_web",
       "version": "0.0.0",
       "dependencies": {
+        "@tosspayments/tosspayments-sdk": "^2.3.4",
         "axios": "^1.7.9",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1208,6 +1209,11 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tosspayments/tosspayments-sdk": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@tosspayments/tosspayments-sdk/-/tosspayments-sdk-2.3.4.tgz",
+      "integrity": "sha512-YypRXqS+9XtQew5TQBa21Ww8Z7QH+fOkuedfH/BaomsCqBv3qS4wMNCSYrq8pxQ7NBOOuPDw0DLvY7Bg5FWNmQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tosspayments/tosspayments-sdk": "^2.3.4",
     "axios": "^1.7.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tosspayments/tosspayments-sdk": "^2.3.4",
+    "@tosspayments/payment-sdk": "^1.7.0",
     "axios": "^1.7.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import './App.css'
 import {BrowserRouter, Route, Routes} from "react-router-dom";
+import { RecoilRoot } from "recoil";
 import NavBar from "./components/NavBar.jsx";
 import Home from "./pages/Home.jsx";
 import SignIn from "./pages/SignIn.jsx";
@@ -7,23 +8,27 @@ import SignUp from "./pages/SignUp.jsx";
 import CampaignCreate from "./pages/CampaignCreate.jsx";
 import CampaignDetail from "./pages/CampaignDetail.jsx";
 import Orders from "./pages/Orders.jsx";
+import PaymentSuccess from "./pages/PaymentSuccess.jsx";
 
 function App() {
   return (
     <>
+      <RecoilRoot>
         <BrowserRouter>
-            <NavBar />
-            <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/signin" element={<SignIn />} />
-                <Route path="/signup" element={<SignUp />} />
-                <Route path="/campaigns/create" element={<CampaignCreate />} />
-                <Route path="/campaigns/:id" element={<CampaignDetail />} />
-                <Route path="/orders" element={<Orders />} />
-            </Routes>
+          <NavBar />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/signin" element={<SignIn />} />
+            <Route path="/signup" element={<SignUp />} />
+            <Route path="/campaigns/create" element={<CampaignCreate />} />
+            <Route path="/campaigns/:id" element={<CampaignDetail />} />
+            <Route path="/orders" element={<Orders />} />
+            <Route path="/success" element={<PaymentSuccess />} />
+          </Routes>
         </BrowserRouter>
+      </RecoilRoot>
     </>
   )
 }
 
-export default App
+export default App;

--- a/src/components/TossPaymentWidget.jsx
+++ b/src/components/TossPaymentWidget.jsx
@@ -1,14 +1,12 @@
 import { loadTossPayments } from "@tosspayments/tosspayments-sdk";
 import { useEffect, useState } from "react";
-import { useSetRecoilState } from "recoil";
-import { orderDataState } from "../recoil/atoms";
+import axiosInstance from "../api/axiosInstance.js";
 
 const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
 
 const TossPaymentWidget = ({ orderData }) => {
   const [ready, setReady] = useState(false);
   const [widgets, setWidgets] = useState(null);
-  const setOrderData = useSetRecoilState(orderDataState);
 
   useEffect(() => {
     async function fetchPaymentWidgets() {
@@ -77,10 +75,12 @@ const TossPaymentWidget = ({ orderData }) => {
           className="button"
           disabled={!ready}
           onClick={async () => {
-            
             try {
-              // 결제 요청 전에 orderData를 저장
-              setOrderData(orderData);
+              // 백엔드 서버의 세션에 주문 데이터 저장
+              await axiosInstance.post("/orders/session", {
+                paymentOrderId: orderData.orderId,
+                amount: orderData.amount
+              });
 
               await widgets.requestPayment({
                 orderId: orderData.orderId,

--- a/src/components/TossPaymentWidget.jsx
+++ b/src/components/TossPaymentWidget.jsx
@@ -1,0 +1,99 @@
+import { loadTossPayments } from "@tosspayments/tosspayments-sdk";
+import { useEffect, useState } from "react";
+
+const clientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+
+const TossPaymentWidget = ({ orderData }) => {
+  const [ready, setReady] = useState(false);
+  const [widgets, setWidgets] = useState(null);
+
+  useEffect(() => {
+    async function fetchPaymentWidgets() {
+      // ------  결제위젯 초기화 ------
+      const tossPayments = await loadTossPayments(clientKey);
+      // 회원 결제
+      const widgets = tossPayments.widgets({
+        customerKey: orderData.customerKey || "ANONYMOUS" //TODO : 회원ID에 대한 UUID를 전달받아야 함
+      });
+      setWidgets(widgets);
+    }
+
+    fetchPaymentWidgets();
+  }, [orderData.customerKey]);
+
+  useEffect(() => {
+    async function renderPaymentWidgets() {
+      if (widgets == null) {
+        return;
+      }
+      // ------ 주문의 결제 금액 설정 ------
+      await widgets.setAmount({
+        currency: "KRW",
+        value: orderData.amount
+      });
+      
+      await Promise.all([
+        // ------  결제 UI 렌더링 ------
+        widgets.renderPaymentMethods({
+          selector: "#payment-method",
+          variantKey: "DEFAULT",
+        }),
+        // ------  이용약관 UI 렌더링 ------
+        widgets.renderAgreement({
+          selector: "#agreement",
+          variantKey: "AGREEMENT",
+        }),
+      ]);
+
+      setReady(true);
+    }
+
+    renderPaymentWidgets();
+  }, [widgets, orderData.amount]);
+
+  useEffect(() => {
+    if (widgets == null) {
+      return;
+    }
+  
+    widgets.setAmount(orderData.amount);
+  }, [widgets, orderData.amount]);
+
+  return (
+    <div className="wrapper">
+      <div className="box_section">
+        {/* 결제 UI */}
+        <div id="payment-method" />
+        {/* 이용약관 UI */}
+        <div id="agreement" />
+        {/* 결제하기 버튼 */}
+        <button
+          className="button"
+          disabled={!ready}
+          onClick={async () => {
+            try {
+              // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
+              // TODO : 하드코딩된 부분 수정
+              await widgets.requestPayment({
+                orderId: orderData.orderId,
+                orderName: orderData.orderName,
+                successUrl: window.location.origin + "/success", // TODO : 성공 및 실패 시 리다이렉트 적용
+                failUrl: window.location.origin + "/fail",
+                customerEmail: orderData.customerEmail || "customer123@gmail.com",
+                customerName: orderData.customerName || "고객",
+                customerMobilePhone: orderData.customerMobilePhone || "01012341234",
+              });
+            } catch (error) {
+              // 에러 처리하기
+              console.error(error);
+            }
+          }}
+        >
+          결제하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TossPaymentWidget;

--- a/src/pages/CampaignCreate.jsx
+++ b/src/pages/CampaignCreate.jsx
@@ -90,7 +90,7 @@ const CampaignCreate = () => {
             startDate,
             endDate,
             goalQuantity,
-            product: {
+            productRequest: {
                 name: productName,
                 description: productDesc,
                 price: productPrice,

--- a/src/pages/CampaignCreate.jsx
+++ b/src/pages/CampaignCreate.jsx
@@ -104,7 +104,7 @@ const CampaignCreate = () => {
 
             alert("캠페인이 성공적으로 등록되었습니다!");
 
-            navigate(`/campaigns/${response.data}`);
+            navigate(`/campaigns/${response.data.campaignId}`);
         } catch (error) {
             console.error("캠페인 생성 실패:", error.response?.data || error.message);
             alert("캠페인 등록에 실패했습니다. 다시 시도해주세요.");

--- a/src/pages/CampaignDetail.jsx
+++ b/src/pages/CampaignDetail.jsx
@@ -3,8 +3,8 @@ import {useNavigate, useParams} from "react-router-dom";
 import styled from "styled-components";
 import axiosInstance from "../api/axiosInstance.js";
 import TossPaymentWidget from "../components/TossPaymentWidget.jsx";
-import { useRecoilValue } from "recoil";
-import { userState } from "../recoil/atoms.js";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { userState, orderDataState } from "../recoil/atoms.js";
 
 const Container = styled.div`
     max-width: 800px;
@@ -78,6 +78,7 @@ const CampaignDetail = () => {
     const [error, setError] = useState(null);
     const [showPayment, setShowPayment] = useState(false);
     const [orderData, setOrderData] = useState(null);
+    const setRecoilOrderData = useSetRecoilState(orderDataState);
 
     useEffect(() => {
         const fetchCampaign = async () => {
@@ -111,17 +112,19 @@ const CampaignDetail = () => {
 
         try {
             // TODO : 결제 위젯에 필요한 데이터 설정
-            setOrderData({
+            const orderData = {
                 orderId: `ORDER_${Date.now()}`,  // 주문번호
                 amount: orderCount * campaign.product.price,  // 결제 금액
                 orderName: `${campaign.product.name} ${orderCount}개`,  // 주문명
                 customerKey: user.uuid,
                 customerEmail: "",  // 이메일 (선택)
                 customerName: "",   // 이름 (선택)
-                customerMobilePhone: "",  // 전화번호 (선택)
+                customerMobilePhone: "01012345678",  // 전화번호 (선택)
                 productId: campaign.product.id,  // 상품 ID
                 orderQuantity: orderCount  // 주문 수량
-            });
+            };
+            setOrderData(orderData);
+            setRecoilOrderData(orderData);
             
             // 결제 위젯 표시
             setShowPayment(true);

--- a/src/pages/CampaignDetail.jsx
+++ b/src/pages/CampaignDetail.jsx
@@ -3,6 +3,8 @@ import {useNavigate, useParams} from "react-router-dom";
 import styled from "styled-components";
 import axiosInstance from "../api/axiosInstance.js";
 import TossPaymentWidget from "../components/TossPaymentWidget.jsx";
+import { useRecoilValue } from "recoil";
+import { userState } from "../recoil/atoms.js";
 
 const Container = styled.div`
     max-width: 800px;
@@ -69,6 +71,7 @@ const OrderButton = styled.button`
 const CampaignDetail = () => {
     const navigate = useNavigate();
     const { id } = useParams();
+    const user = useRecoilValue(userState);
     const [campaign, setCampaign] = useState(null);
     const [orderCount, setOrderCount] = useState(1);
     const [loading, setLoading] = useState(true);
@@ -100,27 +103,32 @@ const CampaignDetail = () => {
             return;
         }
 
+        if (!user.isLoggedIn) {
+            alert("로그인이 필요한 서비스입니다.");
+            navigate("/signin");
+            return;
+        }
+
         try {
-            // 주문 생성 API 호출
-            const response = await axiosInstance.post(`/orders`, {
-                productId: campaign.product.id,
-                orderQuantity: orderCount
-            });
-            
             // TODO : 결제 위젯에 필요한 데이터 설정
             setOrderData({
-                orderId: response.data.orderId || `ORDER_${Date.now()}`,  // 주문번호
+                orderId: `ORDER_${Date.now()}`,  // 주문번호
                 amount: orderCount * campaign.product.price,  // 결제 금액
                 orderName: `${campaign.product.name} ${orderCount}개`,  // 주문명
-                customerKey: "ANONYMOUS",  // 비회원 결제
+                customerKey: user.uuid,
                 customerEmail: "",  // 이메일 (선택)
                 customerName: "",   // 이름 (선택)
-                customerMobilePhone: ""  // 전화번호 (선택)
+                customerMobilePhone: "",  // 전화번호 (선택)
+                productId: campaign.product.id,  // 상품 ID
+                orderQuantity: orderCount  // 주문 수량
             });
             
             // 결제 위젯 표시
             setShowPayment(true);
         } catch (error) {
+            // 에러 발생 시 결제 위젯 숨기기
+            setShowPayment(false);
+            setOrderData(null);
             console.error("주문 생성 실패", error);
             alert("주문이 실패했습니다. 다시 시도해주세요.");        
         }
@@ -143,34 +151,29 @@ const CampaignDetail = () => {
                 <p>시작일: {campaign.startDate}</p>
                 <p>종료일: {campaign.endDate}</p>
                 <p>목표 수량: {campaign.goalQuantity}</p>
-                {/*<p>판매(펀딩)된 수량: {campaign.soldQuantity}</p>*/}
             </Section>
 
             <Section>
                 <h2>상품 정보</h2>
                 <p>상품명: {campaign.product.name}</p>
-                <p>상품설명: {campaign.product.description}</p>
-                <p>가격: {campaign.product.price.toLocaleString()}원</p>
+                <p>가격: {campaign.product.price}원</p>
+                <OrderWrapper>
+                    <OrderLabel>수량:</OrderLabel>
+                    <OrderInput
+                        type="number"
+                        min="1"
+                        value={orderCount}
+                        onChange={(e) => setOrderCount(parseInt(e.target.value))}
+                    />
+                    <OrderButton onClick={handleOrder}>주문하기</OrderButton>
+                </OrderWrapper>
             </Section>
-
-            <Section>
-                <h2>재고 정보</h2>
-                <p>총 재고: {campaign.product.totalQuantity}</p>
-            </Section>
-
-            <OrderWrapper>
-                <OrderLabel>주문 수량</OrderLabel>
-                <OrderInput
-                    type="number"
-                    min="1"
-                    value={orderCount}
-                    onChange={(e) => setOrderCount(e.target.value)}
-                />
-                <OrderButton onClick={handleOrder}>주문하기</OrderButton>
-            </OrderWrapper>
 
             {showPayment && orderData && (
-                <TossPaymentWidget orderData={orderData} />
+                <Section>
+                    <h2>결제</h2>
+                    <TossPaymentWidget orderData={orderData} />
+                </Section>
             )}
         </Container>
     );

--- a/src/pages/PaymentFail.jsx
+++ b/src/pages/PaymentFail.jsx
@@ -1,0 +1,17 @@
+import { useSearchParams } from "react-router-dom";
+
+export function FailPage() {
+  const [searchParams] = useSearchParams();
+
+  return (
+    <div className="result wrapper">
+      <div className="box_section">
+        <h2>
+          결제 실패
+        </h2>
+        <p>{`에러 코드: ${searchParams.get("code")}`}</p>
+        <p>{`실패 사유: ${searchParams.get("message")}`}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PaymentSuccess.jsx
+++ b/src/pages/PaymentSuccess.jsx
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { orderDataState } from "../recoil/atoms";
+
+export function SuccessPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const orderData = useRecoilValue(orderDataState);
+
+  useEffect(() => {
+    // 쿼리 파라미터 값이 결제 요청할 때 보낸 데이터와 동일한지 반드시 확인하세요.
+    // 클라이언트에서 결제 금액을 조작하는 행위를 방지할 수 있습니다.
+    const requestData = {
+      orderId: searchParams.get("orderId"),
+      amount: searchParams.get("amount"),
+      paymentKey: searchParams.get("paymentKey"),
+      productId: orderData?.productId,
+      orderQuantity: orderData?.orderQuantity
+    };
+
+    async function confirm() {
+      const response = await fetch("/orders", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestData),
+      });
+
+      const json = await response.json();
+
+      if (!response.ok) {
+        // 결제 실패 비즈니스 로직을 구현하세요.
+        navigate(`/fail?message=${json.message}&code=${json.code}`);
+        return;
+      }
+
+      // 결제 성공 비즈니스 로직을 구현하세요.
+    }
+
+    if (orderData) {
+      confirm();
+    } else {
+      navigate("/");
+    }
+  }, [navigate, searchParams, orderData]);
+
+  return (
+    <div className="result wrapper">
+      <div className="box_section">
+        <h2>
+          결제 성공
+        </h2>
+        <p>{`주문번호: ${searchParams.get("orderId")}`}</p>
+        <p>{`결제 금액: ${Number(
+          searchParams.get("amount")
+        ).toLocaleString()}원`}</p>
+        <p>{`paymentKey: ${searchParams.get("paymentKey")}`}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -66,12 +66,13 @@ const SignIn = () => {
     const handleSignIn = async (e) => {
         e.preventDefault();
         try {
-            await axiosInstance.post("/signin", member);
-            console.log("로그인 성공");
-            setUser({
+            const response = await axiosInstance.post("/signin", member);
+            const userData = {
                 isLoggedIn: true,
-            });
-            localStorage.setItem("userState", JSON.stringify({isLoggedIn: true}));
+                uuid: response.data.uuid,
+            };
+            setUser(userData);
+            localStorage.setItem("userState", JSON.stringify(userData));
             navigate("/");
         } catch (error) {
             console.log(error);

--- a/src/recoil/atoms.js
+++ b/src/recoil/atoms.js
@@ -23,3 +23,21 @@ export const errorState = atom({
     key: "errorState",
     default: null,
 });
+
+const persistedOrderData = JSON.parse(localStorage.getItem("orderDataState")) || null;
+
+export const orderDataState = atom({
+    key: "orderDataState",
+    default: persistedOrderData,
+    effects: [
+        ({ onSet }) => {
+            onSet((newValue) => {
+                if (newValue === null) {
+                    localStorage.removeItem("orderDataState");
+                } else {
+                    localStorage.setItem("orderDataState", JSON.stringify(newValue));
+                }
+            });
+        },
+    ],
+});


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/d8b56ae3-f764-4806-a9c1-37f9e4598bd8" width="650" height="400" />

해당 PR에서 구현된 부분은 빨간 네모로 표시된 부분입니다!

## 결제위젯 렌더요청
[TossPaymentWidget.jsx](https://github.com/cholog-project/wiseshop_web/pull/4/files#diff-9609d1e35d301baa78d4f4e3f2606c59bee0cf47908adb32ceae1b91a6cced47)에 결제위젯의 구성요소 및 결제하기 버튼을 눌렀을 때 어떤 데이터를 전달하는지를 확인할 수 있습니다.

### 결제하기 버튼을 눌렀을 때, 결제요청 정보를 백엔드 서버의 세션에 저장
- 결제하기 버튼을 누르면, **orderId**와 **amount** 값을 백엔드 서버의 세션에 [저장](https://github.com/cholog-project/wiseshop_web/pull/4/files#diff-9609d1e35d301baa78d4f4e3f2606c59bee0cf47908adb32ceae1b91a6cced47R77-R83)하도록 합니다.
<img src="https://github.com/user-attachments/assets/5a94a520-6bce-4217-8e87-1efec285d120" width="500" height="250" />

- 해당 값은 백엔드 서버에서 Toss PG 서버로 **결제승인 API**를 요청할 때, 세션 값을 조회하여 요청과 승인 사이의 무결성 검증에 활용됩니다.
- **orderId**는 [클라이언트에서 생성](https://github.com/cholog-project/wiseshop_web/pull/4/files#diff-93ce507cba417d236edb6685e09f85934aff4a70dff0b1187e25dbd87d48c51cR116)한 주문ID입니다. 경과한 시간을 밀리초 단위까지 나타내는 값으로 주문ID를 만들어 전달합니다.

## 결제요청
TossPaymentWidget.jsx에서 [**Toss SDK**를 활용하여 결제요청](https://github.com/cholog-project/wiseshop_web/pull/4/files#diff-9609d1e35d301baa78d4f4e3f2606c59bee0cf47908adb32ceae1b91a6cced47R85-R93)을 합니다. 이 결제요청에서의 클라이언트는 **리액트**, 서버는 **Toss PG 서버**입니다.

## 결제요청(인증) 성공 시, 리다이렉트
결제요청이 성공되면, 요청 값에 지정한 `successURL`로 리다이렉트합니다. 성공 시, 동작하는 기능은 [PaymentSuccess.jsx](https://github.com/cholog-project/wiseshop_web/pull/4/files#diff-f943909f92bedb16e57251da5881c121a1cd45046f97583b389511da8b957c0fR14-R40)에서 확인할 수 있습니다.
 - 결제승인을 요청할 때, `POST /orders`를 호출합니다.  